### PR TITLE
Fix: duplicate command in make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ help:
 	@echo "  install-deps                      Install project dependencies to the vendor directory"
 	@echo "  setup                             Install project dependencies for local development"
 	@echo "  run-local-infra                   Runs project infra for local development"
-	@echo "  run-local-infra                   Stops project infra for local development and removes containers"
+	@echo "  stop-local-infra                  Stops project infra for local development and removes containers"
 	@echo "  sync-db                           Actualises network store database for local development"
 	@echo "  sync-test-db                      Actualises network store database for running tests locally"
-	@echo "  swagger                      	    Generate swagger documentation based on comments in api/handlers"
+	@echo "  swagger                      	   Generate swagger documentation based on comments in api/handlers"
 	@echo "  swagger-format                    Run swagger comments formatting"
 
 


### PR DESCRIPTION
Signed-off-by: Artem Zhmaka <zhmaka99@gmail.com>

* Resolves: # [issue 10](https://github.com/make-software/casper-dao-middleware/issues/10)

### Summary

Fixed duplicated command in make help

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required


